### PR TITLE
Dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   tests/ordered_map/iterator_tests.cpp
   tests/ordered_map/constructor_tests.cpp
   tests/ordered_map/find_tests.cpp
+  tests/ordered_map/move_to_front_tests.cpp
 )
 target_link_libraries(tests PRIVATE ordered_map Catch2::Catch2WithMain)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   tests/doubly_linked_list/pop_front_tests.cpp
   tests/doubly_linked_list/push_back_tests.cpp
   tests/doubly_linked_list/push_front_tests.cpp
+  tests/doubly_linked_list/constructor_tests.cpp
   tests/doubly_linked_list/clear_tests.cpp
   tests/doubly_linked_list/erase_tests.cpp
   tests/doubly_linked_list/move_to_begin_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   tests/doubly_linked_list/clear_tests.cpp
   tests/doubly_linked_list/erase_tests.cpp
   tests/doubly_linked_list/move_to_begin_tests.cpp
+  tests/doubly_linked_list/emplace_back_tests.cpp
   tests/ordered_map/size_tests.cpp
   tests/ordered_map/insertion_tests.cpp
   tests/ordered_map/lookup_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(
   tests/doubly_linked_list/push_front_tests.cpp
   tests/doubly_linked_list/clear_tests.cpp
   tests/doubly_linked_list/erase_tests.cpp
+  tests/doubly_linked_list/move_to_begin_tests.cpp
   tests/ordered_map/size_tests.cpp
   tests/ordered_map/insertion_tests.cpp
   tests/ordered_map/lookup_tests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   tests/ordered_map/lookup_tests.cpp
   tests/ordered_map/iterator_tests.cpp
   tests/ordered_map/constructor_tests.cpp
+  tests/ordered_map/find_tests.cpp
 )
 target_link_libraries(tests PRIVATE ordered_map Catch2::Catch2WithMain)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   tests/doubly_linked_list/push_back_tests.cpp
   tests/doubly_linked_list/push_front_tests.cpp
   tests/doubly_linked_list/clear_tests.cpp
+  tests/doubly_linked_list/erase_tests.cpp
   tests/ordered_map/size_tests.cpp
   tests/ordered_map/insertion_tests.cpp
   tests/ordered_map/lookup_tests.cpp

--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ ordered_map/
    ./build.sh
    ```
 
-## Future Improvements
+## Future Features
+
+- [ ] Add `move_to_front` and `move_to_back` operations in ordered_map to re-order entries (without affecting or copying the entry value)
 
 - [ ] Add const iterators
 - [ ] Add reverse iterators
@@ -206,8 +208,7 @@ ordered_map/
 - [ ] **DoublyLinkedList:** Add `erase` method to erase elements given their iterator
 - [ ] **DoublyLinkedList:** Add pre and post decrement operators
 - [ ] **DoublyLinkedList:** Test front(), back(), insertion and deletion functions for copying behavior
-- [ ] **OrderedMap:** Add support for initializing map with 
+- [ ] **OrderedMap:** Add support for initializing map with
 - [ ] **OrderedMap:** Add support for custom hash functions
 - [ ] **OrderedMap:** Add `erase` method to erase elements given their iterator or key
 - [ ] Test for memory leaks
-

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -59,6 +59,18 @@ private:
 
 public:
     DoublyLinkedList() : head(nullptr), tail(nullptr), _size(0) {}
+
+    DoublyLinkedList(std::initializer_list<T> init_list) : DoublyLinkedList() {
+        for (const auto& value : init_list) push_back(value);
+    }
+
+    template <typename ParamIterator>
+    DoublyLinkedList(ParamIterator begin, ParamIterator end) : DoublyLinkedList() {
+        for (auto it = begin; it != end; it++) {
+            push_back(*it);
+        }
+    }
+
     ~DoublyLinkedList() {
         clear();
     }

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -26,10 +26,7 @@ private:
     Node<T>* tail;
     int _size;
 
-
-    template<typename U>
-    void push_back_internal(U&& value) {
-        auto new_node = std::make_unique<Node<T>>(std::forward<U>(value), tail, nullptr);
+    void link_new_back_node(std::unique_ptr<Node<T>> new_node) {
         if (!head) {
             head = std::move(new_node);
             tail = head.get();
@@ -39,6 +36,12 @@ private:
             tail = tail->next.get();
         }
         ++_size;
+    }
+
+    template<typename U>
+    void push_back_internal(U&& value) {
+        auto new_node = std::make_unique<Node<T>>(std::forward<U>(value), tail, nullptr);
+        link_new_back_node(std::move(new_node));
     }
 
     template<typename U>
@@ -286,16 +289,7 @@ public:
     template <typename... Args>
     void emplace_back(Args&&... args) {
         auto new_node = std::make_unique<Node<T>>(tail, nullptr, std::forward<Args>(args)...);
-        
-        if (!head) {
-            head = std::move(new_node);
-            tail = head.get();
-        } else {
-            tail->next = std::move(new_node);
-            tail->next->prev = tail;
-            tail = tail->next.get();
-        }
-        ++_size;
+        link_new_back_node(std::move(new_node));
     }
 
 

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -218,4 +218,17 @@ public:
         return it;
     }
 
+    void move_to_begin(Iterator it) {
+        if (empty()) throw std::out_of_range("List is empty");
+        if (it == end()) throw std::out_of_range("Invalid iterator");
+        if (it == begin()) return;
+
+        if (it == back_iterator()) {
+            push_front(pop_back());
+        }
+        else {
+            push_front(erase_middle_node(it.current_node_ptr));
+        }
+    }
+
 };

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -12,6 +12,11 @@ struct Node {
     template<typename U>
     Node(U&& a_value, Node* a_prev, std::unique_ptr<Node> a_next)
         : value(std::forward<U>(a_value)), prev(a_prev), next(std::move(a_next)) {}
+
+    template <typename... Args>
+    Node(Node* p, std::unique_ptr<Node> n, Args&&... args)
+    : value(std::forward<Args>(args)...), prev(p), next(std::move(n)) {}
+
 };
 
 template <typename T>
@@ -187,7 +192,7 @@ public:
     }
 
     void clear() {
-        while(size() > 0) {
+        while(head) {
             pop_back();
         }
     }
@@ -277,5 +282,21 @@ public:
         auto extracted = extract_node_and_link_prev_with_next(it.current_node_ptr);
         emplace_node_before(std::move(extracted), head.get());
     }
+
+    template <typename... Args>
+    void emplace_back(Args&&... args) {
+        auto new_node = std::make_unique<Node<T>>(tail, nullptr, std::forward<Args>(args)...);
+        
+        if (!head) {
+            head = std::move(new_node);
+            tail = head.get();
+        } else {
+            tail->next = std::move(new_node);
+            tail->next->prev = tail;
+            tail = tail->next.get();
+        }
+        ++_size;
+    }
+
 
 };

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -49,6 +49,13 @@ private:
         _size++;
     }
     
+    T erase_middle_node(Node<T>* node) {
+        T value = node->value;
+        node->next->prev = node->prev;
+        node->prev->next = std::move(node->next);
+        _size--;
+        return value;
+    }
 
 public:
     DoublyLinkedList() : head(nullptr), tail(nullptr), _size(0) {}
@@ -192,4 +199,19 @@ public:
     Iterator back_iterator() {
         return Iterator(tail);
     }
+
+
+    Iterator erase(Iterator it) {
+        if (empty()) throw std::out_of_range("List is empty");
+        if (it == end()) throw std::out_of_range("Invalid iterator");
+
+        Iterator target_it = it++;
+
+        target_it == begin() ? pop_front() : 
+        target_it == back_iterator() ? pop_back() : 
+        erase_middle_node(target_it.current_node_ptr);
+        
+        return it;
+    }
+
 };

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -9,8 +9,9 @@ struct Node {
     std::unique_ptr<Node> next;
     Node* prev;
 
-    Node(const T& a_value, Node* a_prev, std::unique_ptr<Node> a_next)
-        : value(a_value), prev(a_prev), next(std::move(a_next)) {}
+    template<typename U>
+    Node(U&& a_value, Node* a_prev, std::unique_ptr<Node> a_next)
+        : value(std::forward<U>(a_value)), prev(a_prev), next(std::move(a_next)) {}
 };
 
 template <typename T>
@@ -45,15 +46,26 @@ public:
         return tail->value;
     }
 
-    void push_back(const T& value) {
+    template<typename U>
+    void push_back_internal(U&& value) {
+        auto new_node = std::make_unique<Node<T>>(std::forward<U>(value), tail, nullptr);
         if (!head) {
-            head = std::make_unique<Node<T>>(value, nullptr, nullptr);
+            head = std::move(new_node);
             tail = head.get();
         } else {
-            tail->next = std::make_unique<Node<T>>(value, tail, nullptr);
+            tail->next = std::move(new_node);
+            tail->next->prev = tail;
             tail = tail->next.get();
         }
-        _size++;
+        ++_size;
+    }
+
+    void push_back(T&& value) {
+        push_back_internal(std::move(value));
+    }
+
+    void push_back(const T& value) {
+        push_back_internal(value);
     }
 
     T pop_back() {

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -21,6 +21,35 @@ private:
     Node<T>* tail;
     int _size;
 
+
+    template<typename U>
+    void push_back_internal(U&& value) {
+        auto new_node = std::make_unique<Node<T>>(std::forward<U>(value), tail, nullptr);
+        if (!head) {
+            head = std::move(new_node);
+            tail = head.get();
+        } else {
+            tail->next = std::move(new_node);
+            tail->next->prev = tail;
+            tail = tail->next.get();
+        }
+        ++_size;
+    }
+
+    template<typename U>
+    void push_front_internal(U&& value) {
+        auto new_node = std::make_unique<Node<T>>(std::forward<U>(value), nullptr, std::move(head));
+        if (new_node->next) {
+            new_node->next->prev = new_node.get();
+        }
+        else {
+            tail = new_node.get();
+        }
+        head = std::move(new_node);
+        _size++;
+    }
+    
+
 public:
     DoublyLinkedList() : head(nullptr), tail(nullptr), _size(0) {}
     ~DoublyLinkedList() {
@@ -46,19 +75,7 @@ public:
         return tail->value;
     }
 
-    template<typename U>
-    void push_back_internal(U&& value) {
-        auto new_node = std::make_unique<Node<T>>(std::forward<U>(value), tail, nullptr);
-        if (!head) {
-            head = std::move(new_node);
-            tail = head.get();
-        } else {
-            tail->next = std::move(new_node);
-            tail->next->prev = tail;
-            tail = tail->next.get();
-        }
-        ++_size;
-    }
+    
 
     void push_back(T&& value) {
         push_back_internal(std::move(value));
@@ -88,16 +105,12 @@ public:
         return popped_value;
     }
 
+    void push_front(T&& value) {
+        push_front_internal(std::move(value));
+    }
+
     void push_front(const T& value) {
-        if (!head) {
-            head = std::make_unique<Node<T>>(value, nullptr, nullptr);
-            tail = head.get();
-        } else {
-            auto new_node = std::make_unique<Node<T>>(value, nullptr, std::move(head));
-            new_node->next->prev = new_node.get();
-            head = std::move(new_node);
-        }
-        _size++;
+        push_front_internal(value);
     }
 
     T pop_front() {

--- a/include/doubly_linked_list.hpp
+++ b/include/doubly_linked_list.hpp
@@ -147,13 +147,14 @@ public:
 
     class Iterator {
         Node<T>* current_node_ptr;
+        DoublyLinkedList<T>* list_ptr;
 
-        Iterator(Node<T>* a_current) : current_node_ptr(a_current) {}
+        Iterator(Node<T>* a_current, DoublyLinkedList<T>* a_list_ptr) : current_node_ptr(a_current), list_ptr(a_list_ptr) {}
         
         friend class DoublyLinkedList<T>;
 
     public:
-        Iterator() : current_node_ptr(nullptr) {}
+        Iterator() : current_node_ptr(nullptr), list_ptr(nullptr) {}
         
         bool operator==(const Iterator& other) const {
             return current_node_ptr == other.current_node_ptr;
@@ -181,7 +182,10 @@ public:
         }
 
         Iterator& operator--() {
-            if (current_node_ptr) {
+            if (current_node_ptr == nullptr) {
+                current_node_ptr = list_ptr->tail;
+            }
+            else if (current_node_ptr) {
                 current_node_ptr = current_node_ptr->prev;
             }
             return *this;
@@ -189,15 +193,15 @@ public:
     };
 
     Iterator begin() {
-        return Iterator(head.get());
+        return Iterator(head.get(), this);
     }
 
     Iterator end() {
-        return Iterator(nullptr);
+        return Iterator(nullptr, this);
     }
 
     Iterator back_iterator() {
-        return Iterator(tail);
+        return Iterator(tail, this);
     }
 
 

--- a/include/ordered_map.hpp
+++ b/include/ordered_map.hpp
@@ -33,11 +33,21 @@ public:
 
     void insert(const KeyType& key, const ValueType& value) {
         if (_map.find(key) == _map.end()) {
-            _list.push_back(std::make_pair(key, value));
+            _list.emplace_back(key, value);
             _map[key] = _list.back_iterator();
         }
         else {
-            *_map.find(key)->second = std::make_pair(key, value);
+            (*_map[key]).second = value;
+        }
+    }
+
+    void insert(const KeyType& key, ValueType&& value) {
+        if (_map.find(key) == _map.end()) {
+            _list.emplace_back(key, std::move(value));
+            _map[key] = _list.back_iterator();
+        }
+        else {
+            (*_map[key]).second = std::move(value);
         }
     }
 
@@ -122,7 +132,6 @@ public:
         if (_map.find(key) == _map.end()) {
             throw std::out_of_range("Key not found in ordered map");
         }
-        _list.push_front(std::make_pair(key, std::move(at(key))));
-        _list.erase(_map[key]);
+        _list.move_to_begin(_map[key]);
     }
 };

--- a/include/ordered_map.hpp
+++ b/include/ordered_map.hpp
@@ -118,4 +118,11 @@ public:
         return _map.find(key) == _map.end() ? end() : Iterator(_map[key]);
     }
 
+    void move_to_front(const KeyType& key) {
+        if (_map.find(key) == _map.end()) {
+            throw std::out_of_range("Key not found in ordered map");
+        }
+        _list.push_front(std::make_pair(key, std::move(at(key))));
+        _list.erase(_map[key]);
+    }
 };

--- a/include/ordered_map.hpp
+++ b/include/ordered_map.hpp
@@ -113,6 +113,9 @@ public:
         }
         return Iterator(_list.back_iterator());
     }
-    
+
+    Iterator find(const KeyType& key) {
+        return _map.find(key) == _map.end() ? end() : Iterator(_map[key]);
+    }
 
 };

--- a/tests/doubly_linked_list/constructor_tests.cpp
+++ b/tests/doubly_linked_list/constructor_tests.cpp
@@ -1,0 +1,59 @@
+#include <catch2/catch_test_macros.hpp>
+#include "doubly_linked_list.hpp"
+#include "../tests_utils.hpp"
+#include <set>
+TEST_CASE("Default constructor creates an empty list", "[constructor]") {
+    DoublyLinkedList<int> list;
+    REQUIRE(list.empty());
+}
+
+TEST_CASE("Constructor with initializer list {1, 2} creates a list with the elements in the initializer list", "[constructor]") {
+    DoublyLinkedList<int> list = {1, 2};
+    REQUIRE(list.size() == 2);
+    REQUIRE(list.front() == 1);
+    REQUIRE(list.back() == 2);
+}
+
+TEST_CASE("Constructor with initializer list {1, 2, 3, 4, 5} creates a list with the elements in the initializer list", "[constructor]") {
+    DoublyLinkedList<int> list = {1, 2, 3, 4, 5};
+    int value = 1;
+    for (auto it = list.begin(); it != list.end(); ++it) {
+        REQUIRE(*it == value++);
+    }
+}
+
+TEST_CASE("Constructor with vector of size 10 creates a list with 10 elements", "[constructor]") {
+    std::vector<int> vec(10);
+    DoublyLinkedList<int> list(vec.begin(), vec.end());
+    REQUIRE(list.size() == 10);
+}
+
+TEST_CASE("Constructor with vector {1, 2, 3, 4, 5} creates a list with the elements in the vector", "[constructor]") {
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+    DoublyLinkedList<int> list(vec.begin(), vec.end());
+    
+    auto vec_it = vec.begin();
+    auto list_it = list.begin();
+
+    while (vec_it != vec.end()) {
+        REQUIRE(*list_it == *vec_it);
+        ++vec_it; ++list_it;
+    }
+    REQUIRE(list_it == list.end());
+    REQUIRE(vec_it == vec.end());
+}
+
+TEST_CASE("Constructor with set of strings creates a list with the elements in the set", "[constructor]") {
+    std::set<std::string> set = {"hello", "world", "test"};
+    DoublyLinkedList<std::string> list(set.begin(), set.end());
+    
+    auto set_it = set.begin();
+    auto list_it = list.begin();
+
+    while (set_it != set.end()) {
+        REQUIRE(*list_it == *set_it);
+        ++set_it; ++list_it;
+    }
+    REQUIRE(list_it == list.end());
+    REQUIRE(set_it == set.end());
+}

--- a/tests/doubly_linked_list/emplace_back_tests.cpp
+++ b/tests/doubly_linked_list/emplace_back_tests.cpp
@@ -1,0 +1,15 @@
+#include <catch2/catch_test_macros.hpp>
+#include "doubly_linked_list.hpp"
+#include "../tests_utils.hpp"
+
+TEST_CASE("emplace_back one value in an empty list makes size = 1", "[emplace_back]") {
+    DoublyLinkedList<int> list;
+    list.emplace_back(1);
+    REQUIRE(list.size() == 1);
+}
+
+TEST_CASE("emplace_back one pair in an empty list makes size = 1", "[emplace_back]") {
+    DoublyLinkedList<std::pair<int, int>> list;
+    list.emplace_back(1, 2);
+    REQUIRE(list.size() == 1);
+}

--- a/tests/doubly_linked_list/erase_tests.cpp
+++ b/tests/doubly_linked_list/erase_tests.cpp
@@ -1,0 +1,103 @@
+#include "doubly_linked_list.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("calling erase on an empty list throws an exception", "[erase]") {
+    DoublyLinkedList<int> list;
+    REQUIRE_THROWS_AS(list.erase(list.begin()), std::out_of_range);
+}
+
+TEST_CASE("push_back 1, call erase on end throws an exception", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    REQUIRE_THROWS_AS(list.erase(list.end()), std::out_of_range);
+}
+
+TEST_CASE("push_back 1, call erase on begin returns end iterator", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    REQUIRE(list.erase(list.begin()) == list.end());
+}
+
+TEST_CASE("push_back 1, call erase on begin makes the list empty", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.erase(list.begin());
+    REQUIRE(list.empty());
+}
+
+TEST_CASE("push_back 1, 2, call erase on begin makes the front equal 2", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    list.erase(list.begin());
+    REQUIRE(list.front() == 2);
+}
+
+TEST_CASE("push_back 1, 2, call erase on back_iterator makes back equal 1", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    list.erase(list.back_iterator());
+    REQUIRE(list.back() == 1);
+}
+
+TEST_CASE("push_back 1, 2, call erase on begin returns iterator to 2", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    auto it = list.erase(list.begin());
+    REQUIRE(*it == 2);
+}
+
+TEST_CASE("push_back 1, 2, 3, call erase on second element makes list size = 2", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    list.push_back(3);
+    auto it = list.begin(); list.erase(++it);
+
+    REQUIRE(list.size() == 2);
+}
+
+TEST_CASE("push_back 1, 2, 3, call erase on second element front = 1, back = 3", "[erase]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    list.push_back(3);
+    auto it = list.begin(); list.erase(++it);
+    
+    REQUIRE(list.front() == 1);
+    REQUIRE(list.back() == 3);
+}
+
+TEST_CASE("push_back 10,000 elements, erase all elements", "[erase]") {
+    DoublyLinkedList<int> list;
+    for (int i = 0; i < 10000; i++) {
+        list.push_back(i);
+    }
+
+    auto it = list.begin();
+    while (it != list.end()) {
+        it = list.erase(it);
+    }
+
+    REQUIRE(list.empty());
+}
+
+TEST_CASE("push_back 10,000 elements, erase every other element", "[erase]") {
+    DoublyLinkedList<int> list;
+    for (int i = 0; i < 10000; i++) {
+        list.push_back(i);
+    }
+
+    auto it = list.begin();
+    while (it != list.end()) {
+        it = list.erase(it);
+        if (it != list.end()) {
+            it++;
+        }
+    }
+
+    REQUIRE(list.size() == 5000);
+}
+

--- a/tests/doubly_linked_list/front_and_back.cpp
+++ b/tests/doubly_linked_list/front_and_back.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include "doubly_linked_list.hpp"
 #include <stdexcept>
+#include "../tests_utils.hpp"
 
 TEST_CASE("Canary test", "[canary]") {
     REQUIRE(true);
@@ -9,6 +10,27 @@ TEST_CASE("Canary test", "[canary]") {
 TEST_CASE("front on an empty list throws an exception", "[front]") {
     DoublyLinkedList<int> list;
     REQUIRE_THROWS_AS(list.front(), std::out_of_range);
+}
+
+TEST_CASE("front on a list with one element returns the element", "[front]") {
+    DoublyLinkedList<int> list = {1};
+    REQUIRE(list.front() == 1);
+}
+
+TEST_CASE("front on a list with {1, 2} returns 1", "[front]") {
+    DoublyLinkedList<int> list = {1, 2};
+    REQUIRE(list.front() == 1);
+}
+
+TEST_CASE("front on a list with a MoveCopyFlag element returns the element without copying it", "[front]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    list.push_back(MoveCopyFlag());
+    REQUIRE(list.front().state == "default, moved");
+}
+
+TEST_CASE("front on a list constructed with initializer list of MoveCopyFlag returns the element copied once", "[front]") {
+    DoublyLinkedList<MoveCopyFlag> list = {MoveCopyFlag()};
+    REQUIRE(list.front().state == "default, copied");
 }
 
 TEST_CASE("back on an empty list throws an exception", "[back]") {

--- a/tests/doubly_linked_list/iterator_tests.cpp
+++ b/tests/doubly_linked_list/iterator_tests.cpp
@@ -169,3 +169,11 @@ TEST_CASE("push_back 1, 2, dereferencing back iterator returns 2", "[back_iterat
     REQUIRE(*it == 2);
 }
 
+TEST_CASE("push_back 1, 2, 3, using decerement (--) on end iterator returns 3", "[back_iterator]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1); list.push_back(2); list.push_back(3);
+    auto it = list.end();
+    --it;
+
+    REQUIRE(*it == 3);
+}

--- a/tests/doubly_linked_list/move_to_begin_tests.cpp
+++ b/tests/doubly_linked_list/move_to_begin_tests.cpp
@@ -1,0 +1,47 @@
+#include <catch2/catch_test_macros.hpp>
+#include "doubly_linked_list.hpp"
+#include "../tests_utils.hpp"
+
+TEST_CASE("move_to_front on an empty list throws an exception", "[move_to_front]") {
+    DoublyLinkedList<int> list;
+    REQUIRE_THROWS_AS(list.move_to_begin(list.begin()), std::out_of_range);
+}
+
+TEST_CASE("push_back 1, 2,move_to_front with end iterator throws an exception", "[move_to_front]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    REQUIRE_THROWS_AS(list.move_to_begin(list.end()), std::out_of_range);
+}
+
+TEST_CASE("push_back 1, 2, move_to_front with begin iterator does nothing", "[move_to_front]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    list.move_to_begin(list.begin());
+    REQUIRE(list.front() == 1);
+    REQUIRE(list.back() == 2);
+}
+
+TEST_CASE("push_back 1, 2, move_to_front with iterator to 2 moves 2 to front", "[move_to_front]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    auto it = list.end();
+    list.move_to_begin(--it);
+    REQUIRE(list.front() == 2);
+    REQUIRE(list.back() == 1);
+}
+
+TEST_CASE("push_back 1, 2, 3, move_to_begin with iterator to 2 moves 2 to front", "[move_to_begin]") {
+    DoublyLinkedList<int> list;
+    list.push_back(1);
+    list.push_back(2);
+    list.push_back(3);
+    auto it = list.begin();
+    list.move_to_begin(++it);
+
+    REQUIRE(list.front() == 2);
+    REQUIRE(*++it == 1);
+    REQUIRE(list.back() == 3);
+}

--- a/tests/doubly_linked_list/move_to_begin_tests.cpp
+++ b/tests/doubly_linked_list/move_to_begin_tests.cpp
@@ -7,37 +7,28 @@ TEST_CASE("move_to_front on an empty list throws an exception", "[move_to_front]
     REQUIRE_THROWS_AS(list.move_to_begin(list.begin()), std::out_of_range);
 }
 
-TEST_CASE("push_back 1, 2,move_to_front with end iterator throws an exception", "[move_to_front]") {
-    DoublyLinkedList<int> list;
-    list.push_back(1);
-    list.push_back(2);
+TEST_CASE("list with 1, 2, move_to_front with end iterator throws an exception", "[move_to_front]") {
+    DoublyLinkedList<int> list = {1, 2};
     REQUIRE_THROWS_AS(list.move_to_begin(list.end()), std::out_of_range);
 }
 
-TEST_CASE("push_back 1, 2, move_to_front with begin iterator does nothing", "[move_to_front]") {
-    DoublyLinkedList<int> list;
-    list.push_back(1);
-    list.push_back(2);
+TEST_CASE("list with 1, 2, move_to_front with begin iterator does nothing", "[move_to_front]") {
+    DoublyLinkedList<int> list = {1, 2};
     list.move_to_begin(list.begin());
     REQUIRE(list.front() == 1);
     REQUIRE(list.back() == 2);
 }
 
-TEST_CASE("push_back 1, 2, move_to_front with iterator to 2 moves 2 to front", "[move_to_front]") {
-    DoublyLinkedList<int> list;
-    list.push_back(1);
-    list.push_back(2);
+TEST_CASE("list with 1, 2, move_to_front with iterator to 2 moves 2 to front", "[move_to_front]") {
+    DoublyLinkedList<int> list = {1, 2};
     auto it = list.end();
     list.move_to_begin(--it);
     REQUIRE(list.front() == 2);
     REQUIRE(list.back() == 1);
 }
 
-TEST_CASE("push_back 1, 2, 3, move_to_begin with iterator to 2 moves 2 to front", "[move_to_begin]") {
-    DoublyLinkedList<int> list;
-    list.push_back(1);
-    list.push_back(2);
-    list.push_back(3);
+TEST_CASE("list with 1, 2, 3, move_to_begin with iterator to 2 moves 2 to front", "[move_to_begin]") {
+    DoublyLinkedList<int> list = {1, 2, 3};
     auto it = list.begin();
     list.move_to_begin(++it);
 

--- a/tests/doubly_linked_list/move_to_begin_tests.cpp
+++ b/tests/doubly_linked_list/move_to_begin_tests.cpp
@@ -36,3 +36,53 @@ TEST_CASE("list with 1, 2, 3, move_to_begin with iterator to 2 moves 2 to front"
     REQUIRE(*++it == 1);
     REQUIRE(list.back() == 3);
 }
+
+TEST_CASE("list with 2 MoveCopyFlag elements, move_to_begin with iterator to 1st does nothing, no additional move or copy", "[move_to_begin]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    list.push_back(MoveCopyFlag());
+    list.push_back(MoveCopyFlag());
+    auto it = list.begin();
+    list.move_to_begin(it);
+    REQUIRE(list.front().state == "default, moved");
+    REQUIRE(list.back().state == "default, moved");
+}
+
+TEST_CASE("list with 2 MoveCopyFlag elements constructed with move, move_to_begin with iterator to 2nd moves it to front with no additional move or copy", "[move_to_begin]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    list.push_back(MoveCopyFlag());
+    list.push_back(MoveCopyFlag());
+    auto it = list.begin();
+    auto it_to_second_element = ++it;
+    list.move_to_begin(it_to_second_element);
+    
+    REQUIRE(list.front().state == "default, moved");
+}
+
+TEST_CASE("list with 5 MoveCopyFlag elements copied via initializer list, move_to_begin with iterator to 3rd moves it to front with no additional move or copy", "[move_to_begin]") {
+    DoublyLinkedList<MoveCopyFlag> list = {
+        MoveCopyFlag(),
+        MoveCopyFlag(),
+        MoveCopyFlag(),
+        MoveCopyFlag(),
+        MoveCopyFlag()
+    };
+    auto it = list.begin(); ++it; ++it;
+    list.move_to_begin(it);
+    REQUIRE(list.front().state == "default, copied");
+}
+
+TEST_CASE("list with 5 strings, reversed using move_to_begin", "[move_to_begin]") {
+    DoublyLinkedList<std::string> list = {"a", "b", "c", "d", "e"};
+    auto it = list.begin();
+    while(it != list.end()) {
+        list.move_to_begin(it++);
+    }
+    
+    it = list.begin();
+    REQUIRE(*it++ == "e");
+    REQUIRE(*it++ == "d");
+    REQUIRE(*it++ == "c");
+    REQUIRE(*it++ == "b");
+    REQUIRE(*it++ == "a");
+}
+

--- a/tests/doubly_linked_list/push_back_tests.cpp
+++ b/tests/doubly_linked_list/push_back_tests.cpp
@@ -57,3 +57,27 @@ TEST_CASE("push_back 2, 1 and back returns 1", "[push_back]") {
     list.push_back(1);
     REQUIRE(list.back() == 1);
 }
+
+class MoveCopyFlag {
+        public:
+        std::string state;
+        MoveCopyFlag() : state("default") {}
+        MoveCopyFlag(const MoveCopyFlag& other) : state(other.state + ", copied") {}
+        MoveCopyFlag(MoveCopyFlag&& other) : state(other.state + ", moved") {}
+    };
+
+TEST_CASE("using move with push_back does not copy the value", "[push_back]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    auto object = MoveCopyFlag();
+    list.push_back(std::move(object));
+
+    REQUIRE(list.back().state == "default, moved");
+}
+
+TEST_CASE("using push_back directly copies the value", "[push_back]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    auto object = MoveCopyFlag();
+    list.push_back(object);
+
+    REQUIRE(list.back().state == "default, copied");
+}

--- a/tests/doubly_linked_list/push_back_tests.cpp
+++ b/tests/doubly_linked_list/push_back_tests.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "doubly_linked_list.hpp"
-
+#include "../tests_utils.hpp"
 
 TEST_CASE("push_back one value in an empty list makes size = 1", "[push_back]") {
     DoublyLinkedList<int> list;
@@ -58,14 +58,6 @@ TEST_CASE("push_back 2, 1 and back returns 1", "[push_back]") {
     REQUIRE(list.back() == 1);
 }
 
-class MoveCopyFlag {
-        public:
-        std::string state;
-        MoveCopyFlag() : state("default") {}
-        MoveCopyFlag(const MoveCopyFlag& other) : state(other.state + ", copied") {}
-        MoveCopyFlag(MoveCopyFlag&& other) : state(other.state + ", moved") {}
-    };
-
 TEST_CASE("using move with push_back does not copy the value", "[push_back]") {
     DoublyLinkedList<MoveCopyFlag> list;
     auto object = MoveCopyFlag();
@@ -74,7 +66,7 @@ TEST_CASE("using move with push_back does not copy the value", "[push_back]") {
     REQUIRE(list.back().state == "default, moved");
 }
 
-TEST_CASE("using push_back directly copies the value", "[push_back]") {
+TEST_CASE("passing variable by value to push_back copies the value", "[push_back]") {
     DoublyLinkedList<MoveCopyFlag> list;
     auto object = MoveCopyFlag();
     list.push_back(object);

--- a/tests/doubly_linked_list/push_front_tests.cpp
+++ b/tests/doubly_linked_list/push_front_tests.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "doubly_linked_list.hpp"
-
+#include "../tests_utils.hpp"
 
 
 TEST_CASE("push_front 1, size = 1", "[push_front]") {
@@ -44,4 +44,19 @@ TEST_CASE("push_back 1, push_front 2, pop_back twice, size is 0", "[push_front]"
     list.pop_back();
     list.pop_back();
     REQUIRE(list.size() == 0);
+}
+
+TEST_CASE("using move with push_front does not copy the value", "[push_front]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    auto object = MoveCopyFlag();
+    list.push_front(std::move(object));
+
+    REQUIRE(list.front().state == "default, moved");
+}
+
+TEST_CASE("passing variable by value to push_front copies the value", "[push_front]") {
+    DoublyLinkedList<MoveCopyFlag> list;
+    auto object = MoveCopyFlag();
+    list.push_front(object);
+    REQUIRE(list.front().state == "default, copied");
 }

--- a/tests/ordered_map/find_tests.cpp
+++ b/tests/ordered_map/find_tests.cpp
@@ -1,0 +1,24 @@
+#include "ordered_map.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("calling find on an empty map returns end()", "[find]") {
+    OrderedMap<int, int> o_map;
+    REQUIRE(o_map.find(1) == o_map.end());
+}
+
+TEST_CASE("calling find with a key that does not exist returns end()", "[find]") {
+    OrderedMap<int, int> o_map;
+    o_map.insert(1, 2);
+    REQUIRE(o_map.find(2) == o_map.end());
+}
+
+TEST_CASE("calling find with a key that exists returns an iterator to the key", "[find]") {
+    OrderedMap<int, int> o_map;
+    o_map.insert(1, 2);
+    auto it = o_map.find(1);
+
+    REQUIRE(*it == std::make_pair(1, 2));
+}
+
+
+

--- a/tests/ordered_map/move_to_front_tests.cpp
+++ b/tests/ordered_map/move_to_front_tests.cpp
@@ -1,0 +1,26 @@
+#include <catch2/catch_test_macros.hpp>
+#include "ordered_map.hpp"
+#include "../tests_utils.hpp"
+
+TEST_CASE("move_to_front on an empty map throws an exception", "[move_to_front]") {
+    OrderedMap<int, int> map;
+    REQUIRE_THROWS_AS(map.move_to_front(1), std::out_of_range);
+}
+
+TEST_CASE("move_to_front on a map with one element has the same element at the front", "[move_to_front]") {
+    OrderedMap<int, int> map;
+    map.insert(1, 0);
+    map.move_to_front(1);
+    REQUIRE(map.begin()->first == 1);
+}
+
+TEST_CASE("move_to_front on a map with two elements moves the element to the front", "[move_to_front]") {
+    OrderedMap<int, int> map;
+    map.insert(1, 0);
+    map.insert(2, 0);
+    map.move_to_front(2);
+    REQUIRE(map.begin()->first == 2);
+}
+
+
+

--- a/tests/ordered_map/move_to_front_tests.cpp
+++ b/tests/ordered_map/move_to_front_tests.cpp
@@ -3,24 +3,55 @@
 #include "../tests_utils.hpp"
 
 TEST_CASE("move_to_front on an empty map throws an exception", "[move_to_front]") {
-    OrderedMap<int, int> map;
-    REQUIRE_THROWS_AS(map.move_to_front(1), std::out_of_range);
+    OrderedMap<int, int> o_map;
+    REQUIRE_THROWS_AS(o_map.move_to_front(1), std::out_of_range);
 }
 
 TEST_CASE("move_to_front on a map with one element has the same element at the front", "[move_to_front]") {
-    OrderedMap<int, int> map;
-    map.insert(1, 0);
-    map.move_to_front(1);
-    REQUIRE(map.begin()->first == 1);
+    OrderedMap<int, int> o_map;
+    o_map.insert(1, 0);
+    o_map.move_to_front(1);
+    REQUIRE(o_map.begin()->first == 1);
 }
 
 TEST_CASE("move_to_front on a map with two elements moves the element to the front", "[move_to_front]") {
-    OrderedMap<int, int> map;
-    map.insert(1, 0);
-    map.insert(2, 0);
-    map.move_to_front(2);
-    REQUIRE(map.begin()->first == 2);
+    OrderedMap<int, int> o_map;
+    o_map.insert(1, 0);
+    o_map.insert(2, 0);
+    o_map.move_to_front(2);
+    
+    REQUIRE(o_map.begin()->first == 2);
 }
 
+TEST_CASE("move_to_front does not copy the value", "[move_to_front]") {
+    OrderedMap<int, MoveCopyFlag> o_map;
+    o_map.insert(1, MoveCopyFlag());
+    o_map.insert(2, MoveCopyFlag());
+    o_map.move_to_front(2);
+
+    REQUIRE(o_map.begin()->second.state == "default, moved");
+}
+
+TEST_CASE("map with 5 strings, move_to_front reverses the order of the elements") {
+    OrderedMap<std::string, int> o_map = {
+        {"a", 0},
+        {"b", 0},
+        {"c", 0},
+        {"d", 0},
+        {"e", 0}
+    };
+    
+    auto it = o_map.begin();
+    while (it != o_map.end()) {
+        o_map.move_to_front((it++)->first);
+    }
+    
+    it = o_map.begin();
+    REQUIRE((it++)->first == "e");
+    REQUIRE((it++)->first == "d");
+    REQUIRE((it++)->first == "c");
+    REQUIRE((it++)->first == "b");
+    REQUIRE((it++)->first == "a");
+}
 
 

--- a/tests/tests_utils.hpp
+++ b/tests/tests_utils.hpp
@@ -7,4 +7,14 @@ class MoveCopyFlag {
     MoveCopyFlag() : state("default") {}
     MoveCopyFlag(const MoveCopyFlag& other) : state(other.state + ", copied") {}
     MoveCopyFlag(MoveCopyFlag&& other) : state(other.state + ", moved") {}
+    
+    MoveCopyFlag& operator=(const MoveCopyFlag& other) {
+        state = other.state + ", copied";
+        return *this;
+    }
+    
+    MoveCopyFlag& operator=(MoveCopyFlag&& other) {
+        state = other.state + ", moved";
+        return *this;
+    }
 };

--- a/tests/tests_utils.hpp
+++ b/tests/tests_utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+
+class MoveCopyFlag {
+    public:
+    std::string state;
+    MoveCopyFlag() : state("default") {}
+    MoveCopyFlag(const MoveCopyFlag& other) : state(other.state + ", copied") {}
+    MoveCopyFlag(MoveCopyFlag&& other) : state(other.state + ", moved") {}
+};


### PR DESCRIPTION
### Release the move_to_front feature 

- Release the central feature `move_to_front` which allows for reordering `OrderedMap` entries in constant time `O(1)`.
- Modify the `DoublyLinkedList` and `OrderedMap` internals to adhere to move and copy semantics and avoid unnecessary or unexpected moving / copying of objects.
- Overload constructors to allow for using initializer list and other STL-style iterators to initialize both `DoublyLinkedList` and `OrderedMap`.